### PR TITLE
adds lookups to get the resladst_ons/resgor_ons fields between 2009 and 2014

### DIFF
--- a/ae/bronze/get_ae_csv_data.py
+++ b/ae/bronze/get_ae_csv_data.py
@@ -36,6 +36,20 @@ def get_ae_csv_data(spark: SparkContext, year: int) -> DataFrame:
 
         df = df.join(mpsid, "aekey", "left")
 
+    # recalculate resladst_ons/resgor_ons
+    if 2009 <= year <= 2014:
+        resladst_lkup = (
+            spark.read.table("strategyunit.reference.resladst_to_resladst_ons_lookup")
+            .filter(F.col("year") == year)
+            .drop("year")
+        )
+        df = df.join(resladst_lkup, "resladst", "left")
+
+        resgor_lkup = spark.read.table(
+            "strategyunit.reference.resgor_to_resgor_ons_lookup"
+        )
+        df = df.join(resgor_lkup, "resgor", "left")
+
     # remove the soal/soam columns if they haven't been remaped to lsoa01/msoa01
     if "soal" in df.columns:
         df = df.drop("soal", "soam")

--- a/apc/bronze/get_apc_csv_data.py
+++ b/apc/bronze/get_apc_csv_data.py
@@ -46,6 +46,20 @@ def get_apc_csv_data(spark: SparkContext, year: int) -> DataFrame:
 
         df = df.join(dismeth, "epikey", "left")
 
+    # recalculate resladst_ons/resgor_ons
+    if 2009 <= year <= 2014:
+        resladst_lkup = (
+            spark.read.table("strategyunit.reference.resladst_to_resladst_ons_lookup")
+            .filter(F.col("year") == year)
+            .drop("year")
+        )
+        df = df.join(resladst_lkup, "resladst", "left")
+
+        resgor_lkup = spark.read.table(
+            "strategyunit.reference.resgor_to_resgor_ons_lookup"
+        )
+        df = df.join(resgor_lkup, "resgor", "left")
+
     # remove the soal/soam columns if they haven't been remaped to lsoa01/msoa01
     if "soal" in df.columns:
         df = df.drop("soal", "soam")

--- a/opa/bronze/get_opa_csv_data.py
+++ b/opa/bronze/get_opa_csv_data.py
@@ -56,6 +56,20 @@ def get_opa_csv_data(spark: SparkContext, year: int) -> DataFrame:
             ]
         )
 
+    # recalculate resladst_ons/resgor_ons
+    if 2009 <= year <= 2014:
+        resladst_lkup = (
+            spark.read.table("strategyunit.reference.resladst_to_resladst_ons_lookup")
+            .filter(F.col("year") == year)
+            .drop("year")
+        )
+        df = df.join(resladst_lkup, "resladst", "left")
+
+        resgor_lkup = spark.read.table(
+            "strategyunit.reference.resgor_to_resgor_ons_lookup"
+        )
+        df = df.join(resgor_lkup, "resgor", "left")
+
     # remove the soal/soam columns if they haven't been remaped to lsoa01/msoa01
     if "soal" in df.columns:
         df = df.drop("soal", "soam")


### PR DESCRIPTION
we have the fields resladst / resgor in hes going back to 1989/90. using the [code history databse](https://geoportal.statistics.gov.uk/datasets/5676b8d2432a4beeae61195abb778274/about) we can find the equivalent codes, but this only goes back to 2009.

this PR fills in the equivalent _ons fields for the years we can be confident the lookups are valid